### PR TITLE
feat: add LID (Local ID) support to IsOnWhatsApp and GetUserInfo functions

### DIFF
--- a/types/user.go
+++ b/types/user.go
@@ -24,6 +24,7 @@ type UserInfo struct {
 	Status       string
 	PictureID    string
 	Devices      []JID
+	LID          *JID // The local ID (if available)
 }
 
 type BotListInfo struct {
@@ -83,6 +84,7 @@ type LocalChatSettings struct {
 type IsOnWhatsAppResponse struct {
 	Query string // The query string used
 	JID   JID    // The canonical user ID
+	LID   *JID   // The local ID (if available)
 	IsIn  bool   // Whether the phone is registered or not.
 
 	VerifiedName *VerifiedName // If the phone is a business, the verified business details.


### PR DESCRIPTION
- Add LID field to IsOnWhatsAppResponse struct
- Add LID field to UserInfo struct
- Implement LID Store lookup in IsOnWhatsApp function
- Implement LID Store lookup in GetUserInfo function
- LID format: xxxxx@lid (different from phone number)
- LID is retrieved from local database when available
- Backwards compatible - LID field is optional (*JID)

## Summary by Sourcery

Add optional Local ID (LID) support to user lookup functions by extending response types and querying the LID store.

New Features:
- Include a LID field in the IsOnWhatsAppResponse and UserInfo structs
- Implement Store.LIDs lookup in Client.IsOnWhatsApp to populate LID for each JID
- Implement Store.LIDs lookup in Client.GetUserInfo to populate LID for each JID