### PR TITLE
fix(appstate): dispara recovery automático em LTHash/PatchMAC mismatch

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -161,10 +161,31 @@ func (cli *Client) applyAppStatePatches(
 	if err != nil {
 		if errors.Is(err, appstate.ErrKeyNotFound) {
 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
+		} else if errors.Is(err, appstate.ErrMismatchingLTHash) || errors.Is(err, appstate.ErrMismatchingPatchMAC) {
+			// Local hash state has diverged from the server. Request a fresh recovery
+			// snapshot from the user's primary device. The response will be handled by
+			// handleAppStateRecovery, which deletes the local version and applies the
+			// server's snapshot.
+			go cli.requestAppStateRecovery(context.WithoutCancel(ctx), name)
 		}
 		return state, fmt.Errorf("failed to decode app state %s patches: %w", name, err)
 	}
 	return newState, cli.collectEventsToDispatch(ctx, name, mutations, fullSync, eventsToDispatch)
+}
+
+// requestAppStateRecovery asks the primary device for a fresh snapshot of the given
+// app state collection. This is triggered automatically when DecodePatches returns
+// ErrMismatchingLTHash or ErrMismatchingPatchMAC, which indicate that the local
+// cached hash has diverged from the server's (usually after app state mutations
+// were made on another device while this one was offline, or after an upstream
+// proto version bump).
+func (cli *Client) requestAppStateRecovery(ctx context.Context, name appstate.WAPatchName) {
+	msg := BuildAppStateRecoveryRequest(name)
+	cli.Log.Infof("Requesting app state recovery snapshot for %s due to hash mismatch", name)
+	_, err := cli.SendPeerMessage(ctx, msg)
+	if err != nil {
+		cli.Log.Warnf("Failed to send app state recovery request for %s: %v", name, err)
+	}
 }
 
 func (cli *Client) collectEventsToDispatch(


### PR DESCRIPTION
## Problema

Quando `DecodePatches` retorna `ErrMismatchingLTHash` ou `ErrMismatchingPatchMAC` dentro de `applyAppStatePatches`, o erro só sobe pra cima — nenhum recovery é disparado. A partir desse ponto, qualquer chamada de `SendAppState` falha com `409 conflict` encapsulando o mesmo erro de decode, porque o fluxo de retry em `sendAppState` tenta reaplicar os patches do servidor pelo mesmo caminho que acabou de falhar.

Isso deixa o estado local permanentemente divergente do servidor — o único jeito de recuperar é fazer logout e re-pair da instância, o que é inviável em produção.

Na prática, qualquer endpoint que dependa do protocolo `w:sync:app:state` fica quebrado:
- `/label/chat`, `/label/message`, `/unlabel/*`
- `/chat/archive`, `/chat/pin`, `/chat/mute`

Erro retornado:
```
server returned error updating app state (regular): <error code="409" text="conflict"/>
(also, applying patches in the response failed:
 failed to decode app state regular patches:
 failed to verify patch v275: mismatching LTHash)
```

## Causa raiz

A infraestrutura de recovery já existe no whatsmeow:
- `handleAppStateRecovery` processa `SyncdSnapshotFatalRecoveryResponse` e reconstrói a coleção a partir do snapshot do primary device
- `BuildAppStateRecoveryRequest` constrói a mensagem pra pedir esse snapshot

Mas **nada no client pede esse snapshot** quando o mismatch é detectado localmente — o caminho de recovery só dispara quando o servidor proativamente envia um. Em contas com histórico longo e múltiplos devices, o servidor não envia espontaneamente, e o bot fica preso no 409.

## Fix

Quando `applyAppStatePatches` detecta `ErrMismatchingLTHash` ou `ErrMismatchingPatchMAC`, dispara em goroutine o `BuildAppStateRecoveryRequest(name)` via `SendPeerMessage` pro primary device. O primary responde com um peer data operation que já é roteado pra `handleAppStateRecovery`, que reseta a coleção pro snapshot do servidor.

Padrão igual ao que já é usado pra `ErrKeyNotFound` (`requestMissingAppStateKeys`).

## Como testar

1. Parear uma instância que já tem o bug (qualquer `SendAppState` retorna 409 mismatch)
2. Primeira chamada ainda falha, mas o log mostra:
   ```
   Requesting app state recovery snapshot for regular due to hash mismatch
   ```
3. Aguardar ~5-10s (tempo do primary responder)
4. Próximas chamadas passam com 200 OK

## Resultado em produção

Testei em uma instância real que estava com `mismatching LTHash v275` há semanas. Após aplicar o fix:
- 1ª chamada de label: 500 (dispara recovery)
- ~8s depois, 2ª chamada: 200 OK ✅
- Depois do recovery, apliquei 10 labels em sequência e 10/10 passaram de primeira

## Relacionado

- Mesmo fix proposto no upstream: https://github.com/tulir/whatsmeow/pull/1120
- Este PR aplica o mesmo patch no fork `EvolutionAPI/whatsmeow` pra destravar o Evolution Go sem precisar esperar o merge no tulir

## Changes

`appstate.go`: 21 linhas adicionadas, 0 removidas. Nenhum teste existente quebrou. O novo branch só dispara nos dois erros específicos de mismatch — caminhos saudáveis não são afetados.

## Summary by Sourcery

Trigger automatic app state recovery when local patch decoding detects hash or MAC mismatches to realign client state with the server.

Bug Fixes:
- Ensure app state desynchronization due to LTHash or PatchMAC mismatches is automatically healed instead of leaving the client permanently stuck with 409 conflicts.

Enhancements:
- Add a helper to request app state recovery snapshots from the primary device, reusing the existing recovery infrastructure without affecting healthy code paths.