### PR TITLE
feat: support sending EventMessage (group events)

### DIFF
--- a/send.go
+++ b/send.go
@@ -911,6 +911,8 @@ func getTypeFromMessage(msg *waE2E.Message) string {
 		return "reaction"
 	case msg.PollCreationMessage != nil, msg.PollUpdateMessage != nil:
 		return "poll"
+	case msg.EventMessage != nil:
+		return "event"
 	case getMediaTypeFromMessage(msg) != "":
 		return "media"
 	case msg.Conversation != nil, msg.ExtendedTextMessage != nil, msg.ProtocolMessage != nil:
@@ -1120,6 +1122,14 @@ func (cli *Client) getMessageContent(
 			Tag: "meta",
 			Attrs: waBinary.Attrs{
 				"polltype": pollType,
+			},
+		})
+	}
+	if msgAttrs["type"] == "event" {
+		content = append(content, waBinary.Node{
+			Tag: "meta",
+			Attrs: waBinary.Attrs{
+				"event_type": "creation",
 			},
 		})
 	}


### PR DESCRIPTION
## Summary

WhatsApp group events (`EventMessage`) were effectively **receive-only** in whatsmeow — there was no way to *create/send* one. This adds the two missing pieces so `client.SendMessage` with an `EventMessage` actually renders as an event in the WhatsApp clients.

## Problem

When sending a `&waE2E.Message{EventMessage: ...}`:

- `getTypeFromMessage` had no case for `EventMessage`, so the stanza went out with `type="text"`. The server **ACKs** it, but clients **silently discard** it — it never renders as an event.
- The `<meta event_type="creation">` child node that the protocol expects for event creation was missing (the same way polls require `<meta polltype="creation">`).

Sending `type="event"` *without* the meta node makes the server reject the stanza with error **479**; with both, the event is created and renders correctly.

## Changes (`send.go`)

1. `getTypeFromMessage`: return `"event"` for `msg.EventMessage`.
2. Append a `<meta event_type="creation">` child node for event messages, mirroring the existing poll `<meta polltype="creation">` handling.

## Notes

- The caller must set `Message.MessageContextInfo.MessageSecret` (32 random bytes) so the event's responses (going/not_going `EncEventResponseMessage`) decrypt — same pattern as `BuildPollCreation`.
- Verified end-to-end against a real group: events render with title, description, location, start/end time, reminder and mentions; the going/not-going responses decrypt correctly.
- Enables the `POST /send/event` endpoint in evolution-go.

## Summary by Sourcery

Support sending WhatsApp group EventMessage stanzas by treating them as event-type messages and including required creation metadata.

New Features:
- Allow EventMessage-based group events to be sent via client.SendMessage so they render as events in WhatsApp clients.

Bug Fixes:
- Ensure EventMessage stanzas use the correct "event" type instead of "text" to prevent clients from discarding them.
- Add required event creation meta node to avoid server errors and enable successful event creation.